### PR TITLE
Added rescue blocks to allow some useful output even when there are some errors

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -2,7 +2,7 @@ h1. Rails Indexes
 
 Rails indexes is a small package of 2 rake tasks that scan your application models and displays a list of columns that _probably_ should be indexed.
 
-note: there should be mode fields depending on your application design and custom queries.
+Note: there may be more fields depending on your application design and custom queries.
 
 h2. Installation
 


### PR DESCRIPTION
Hi Elad,

Thanks for your hard work on this one!  The plugin saved me quite a bit of time grabbing the low-hanging index fruit on an application I just inherited. :)

I wasn't able to get the rake tasks to run successfully by default on my app, though, so I added a few rescue blocks to handle error cases (like inability to determine proper table name for association-based finders in controllers (e.g. current_user.widgets.find...)).  

These tweaks don't actually FIX anything, but they do allow the plugin to show SOME indexes even when there are errors searching for others.

Cheers,
-Kali
