### PR TITLE
ignore non ar model.find_xx interface matching

### DIFF
--- a/lib/indexer.rb
+++ b/lib/indexer.rb
@@ -177,11 +177,12 @@ module Indexer
       # if the finder class is "self" or empty (can be a simple "find()" in a model)
       if model_name == "self" || model_name.blank?
         model_name = File.basename(file_name).sub(/\.rb$/,'').camelize
-        table_name = model_name.constantize.table_name            
+        table_name = model_name.constantize.table_name rescue nil
       else
         if model_name.respond_to?(:constantize)
-          if model_name.constantize.respond_to?(:table_name)             
-            table_name = model_name.constantize.table_name
+          model_class = model_name.constantize rescue nil
+          if model_class.respond_to?(:table_name)
+            table_name = model_class.table_name
           end
         end
       end

--- a/test/fixtures/app/models/non_ar_model.rb
+++ b/test/fixtures/app/models/non_ar_model.rb
@@ -1,0 +1,7 @@
+module ANamespace
+  class NonArModel
+    def work
+      NonArModel.find_by_name('not a ar.finder')
+    end
+  end
+end


### PR DESCRIPTION
rescue any exception when doing model_name.constantize, for some special cases that people put non ar models inside app/models with namespace added, and also implemented ar like interface "find_xxx".

I added "test/fixtures/app/models/non_ar_model.rb" for tests, without the fix, some tests will fail, hence it does not need add another test.
