### PR TITLE
Fixes bug in rescue clause in lib/indexer.rb (undefined local variable: e)

### DIFF
--- a/lib/indexer.rb
+++ b/lib/indexer.rb
@@ -188,7 +188,7 @@ module Indexer
             end
           end
         end
-      rescue
+      rescue Exception => e
         puts "ERROR: #{e} in #{line}"
       end
       


### PR DESCRIPTION
Fix "undefined local variable or method `e' for Indexer:Module" error in lib/indexer.rb:192:in`check_line_for_find_indexes'  (bug in rescue clause)
